### PR TITLE
Fix image asset urls

### DIFF
--- a/lib/mapbox-rails/remote_resource_loader.rb
+++ b/lib/mapbox-rails/remote_resource_loader.rb
@@ -23,13 +23,13 @@ class RemoteResourceLoader < Thor
     inside destination_root do
       run('sass-convert -F css -T scss stylesheets/mapbox.css stylesheets/mapbox.css.scss')
       gsub_file 'stylesheets/mapbox.css.scss', 'url(./images/icons-000000.png)', 
-        "image-url('assets/icons-000000.png')"
+        "image-url('icons-000000.png')"
       gsub_file 'stylesheets/mapbox.css.scss', 'url(./images/icons-ffffff.png)', 
-        "image-url('assets/icons-ffffff.png')"
+        "image-url('icons-ffffff.png')"
       gsub_file 'stylesheets/mapbox.css.scss', 'url(./images/icons-000000@2x.png)', 
-        "image-url('assets/icons-000000@2x.png')"
+        "image-url('icons-000000@2x.png')"
       gsub_file 'stylesheets/mapbox.css.scss', 'url(./images/icons-ffffff@2x.png)', 
-        "image-url('assets/icons-ffffff@2x.png')"
+        "image-url('icons-ffffff@2x.png')"
     end
   end
 

--- a/vendor/assets/stylesheets/mapbox.css.scss
+++ b/vendor/assets/stylesheets/mapbox.css.scss
@@ -477,21 +477,21 @@
 
 .leaflet-control-zoom-in, .leaflet-control-zoom-out, .leaflet-popup-close-button, .leaflet-control-layers-toggle, .leaflet-container.dark .map-tooltip .close, .map-tooltip .close, .mapbox-icon {
   opacity: .75;
-  background-image: image-url('assets/icons-000000.png');
+  background-image: image-url('icons-000000.png');
   background-repeat: no-repeat;
   background-size: 26px 260px;
 }
 
 .mapbox-button-icon:before {
   opacity: 1;
-  background-image: image-url('assets/icons-ffffff.png');
+  background-image: image-url('icons-ffffff.png');
   background-size: 26px 260px;
 }
 
 .leaflet-container.dark {
   .leaflet-control-zoom-in, .leaflet-control-zoom-out, .leaflet-control-layers-toggle, .mapbox-icon {
     opacity: 1;
-    background-image: image-url('assets/icons-ffffff.png');
+    background-image: image-url('icons-ffffff.png');
     background-size: 26px 260px;
   }
 }
@@ -554,14 +554,14 @@
 
 @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
   .leaflet-control-zoom-in, .leaflet-control-zoom-out, .leaflet-popup-close-button, .leaflet-control-layers-toggle, .mapbox-icon {
-    background-image: image-url('assets/icons-000000@2x.png');
+    background-image: image-url('icons-000000@2x.png');
   }
   .mapbox-button-icon:before {
-    background-image: image-url('assets/icons-ffffff@2x.png');
+    background-image: image-url('icons-ffffff@2x.png');
   }
   .leaflet-container.dark {
     .leaflet-control-zoom-in, .leaflet-control-zoom-out, .leaflet-control-layers-toggle, .mapbox-icon {
-      background-image: image-url('assets/icons-ffffff@2x.png');
+      background-image: image-url('icons-ffffff@2x.png');
     }
   }
 }


### PR DESCRIPTION
Hi,

I found the rake scripts are out of sync with the mapbox.css.scss file and the asset pipeline.

Firstly, the rake scripts convert .css to .sass and replace a few urls to adapt to Rails asset pipeline. I had to change the path of those asset pipeline commands.

Secondly, the rake script uses the .sass extension, but the file in the vendor folder was a .scss. Probably created without the script.

So, I fixed the script to use scss, the proper paths in image-url, and generated the mapbox.css.scss with the script.

I hope you can make use of it.

Martin
