### PR TITLE
Edit instructions for including MapBox stylesheet assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Add to your `app/assets/javascripts/application.js`
 
 ### Include mapbox stylesheet assets
 
-Add to your `app/assets/stylesheets/application.css`
+Add to your `app/assets/stylesheets/application.css.scss`
 
 ```scss
-*= require mapbox
+@import "mapbox";
 ```
 
 ### Enable mapbox 


### PR DESCRIPTION
- Using require as instructed creates persistent errors
- Using import instead appears to work without a problem
- This addresses the issue ActionView::Template::Error #11 
