### PR TITLE
Added thor as development dependency

### DIFF
--- a/mapbox-rails.gemspec
+++ b/mapbox-rails.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "thor"
 end


### PR DESCRIPTION
Running `rake update-mapbox` requires `thor` as a dependency. This PR adds thor as a development dependency.